### PR TITLE
update bp function

### DIFF
--- a/MoELoRA/layer_ops/layer_ops_interface.py
+++ b/MoELoRA/layer_ops/layer_ops_interface.py
@@ -103,6 +103,8 @@ def moelinear_fwd_inner_bmm_triton(
         kwargs['lora_B_mask'] = lora_B_mask
         kwargs['lora_A_weights_split'] = lora_A_weights_split
         kwargs['lora_B_weights_split'] = lora_B_weights_split
+    elif version in ['v0']:
+        kwargs['x'] = x
     
     if version == 'v0': return _moelinear_fwd_inner_bmm_triton_v0(**kwargs)
     elif version == 'v1': return MoeLinear_Inner_Bmm_Triton_v1.apply(**kwargs)

--- a/MoELoRA/layer_ops/layer_ops_interface.py
+++ b/MoELoRA/layer_ops/layer_ops_interface.py
@@ -16,6 +16,13 @@ from .layer_ops_triton import (
     _moelinear_fwd_inner_bmm_triton_v4,
 )
 
+from .layer_ops_triton_function import (
+    MoeLinear_Inner_Bmm_Triton_v1,
+    MoeLinear_Inner_Bmm_Triton_v2,
+    MoeLinear_Inner_Bmm_Triton_v3,
+    MoeLinear_Inner_Bmm_Triton_v4,
+)
+
 
 def moelinear_fwd_inner_bmm_torch(
         x: torch.Tensor, result: torch.Tensor, 
@@ -53,10 +60,14 @@ def moelinear_fwd_inner_bmm_torch(
     
 def moelinear_fwd_inner_bmm_triton(
         x: torch.Tensor, result: torch.Tensor, 
-        lora_A_weights: torch.Tensor, lora_B_weights: torch.Tensor, 
+        lora_A_weights: torch.Tensor,
+        lora_B_weights: torch.Tensor,
         scalings: torch.Tensor, lora_dropout: torch.nn.Module,
         moe_weights: torch.Tensor, selected_loras: torch.Tensor, 
+        lora_A_weights_split: torch.Tensor = None,
+        lora_B_weights_split: torch.Tensor = None,
         lora_A_mask: Union[torch.Tensor, List[torch.Tensor]] = None,
+        lora_B_mask: Union[torch.Tensor, List[torch.Tensor]] = None,
         version='v4',
     ) -> torch.Tensor:
     """the inner bmm process in MoELinear.forward implemented by triton
@@ -78,18 +89,24 @@ def moelinear_fwd_inner_bmm_triton(
     assert version in ['v1', 'v2', 'v3', 'v4']
     
     kwargs = dict(
-        x=x, result=result,
+        x=lora_dropout(x), result=result,
         lora_A_weights=lora_A_weights, lora_B_weights=lora_B_weights,
         scalings=scalings, lora_dropout=lora_dropout,
         moe_weights=moe_weights, selected_loras=selected_loras
     )
     if version in ['v3', 'v4']: 
         assert lora_A_mask is not None
+        assert lora_B_mask is not None
+        assert lora_A_weights_split is not None
+        assert lora_B_weights_split is not None
         kwargs['lora_A_mask'] = lora_A_mask
+        kwargs['lora_B_mask'] = lora_B_mask
+        kwargs['lora_A_weights_split'] = lora_A_weights_split
+        kwargs['lora_B_weights_split'] = lora_B_weights_split
     
     if version == 'v0': return _moelinear_fwd_inner_bmm_triton_v0(**kwargs)
-    elif version == 'v1': return _moelinear_fwd_inner_bmm_triton_v1(**kwargs)
-    elif version == 'v2': return _moelinear_fwd_inner_bmm_triton_v2(**kwargs)
-    elif version == 'v3': return _moelinear_fwd_inner_bmm_triton_v3(**kwargs)
-    elif version == 'v4': return _moelinear_fwd_inner_bmm_triton_v4(**kwargs)
+    elif version == 'v1': return MoeLinear_Inner_Bmm_Triton_v1.apply(**kwargs)
+    elif version == 'v2': return MoeLinear_Inner_Bmm_Triton_v2.apply(**kwargs)
+    elif version == 'v3': return MoeLinear_Inner_Bmm_Triton_v3.apply(**kwargs)
+    elif version == 'v4': return MoeLinear_Inner_Bmm_Triton_v4.apply(**kwargs)
     else: raise NotImplementedError(f"Unknown version {version} for moelinear_fwd_inner_bmm_triton")

--- a/MoELoRA/layer_ops/layer_ops_triton.py
+++ b/MoELoRA/layer_ops/layer_ops_triton.py
@@ -65,7 +65,7 @@ def _moelinear_fwd_inner_bmm_triton_v4(
     
     ## prepare inputs
     x = x[:, None, :] # shape from (bs, h) to (bs, 1, h)
-    x = lora_dropout(x).view(bs, m, hm) # shape from (bs, 1, h) => (bs, m, h//m)
+    x = x.view(bs, m, hm) # shape from (bs, 1, h) => (bs, m, h//m)
     if k > 1: 
         moe_weights = moe_weights.view(-1)[:, None] # shape from (bs, k) => (bs*k, 1)
         selected_loras = selected_loras.view(-1) # shape from (bs, k) => (bs*k,)
@@ -103,6 +103,9 @@ def _moelinear_fwd_inner_bmm_triton_v4(
     )
     
     ##############################      postprocess output     ##############################
+    # save and return blora_results for backward
+    result_moe = blora_results # shape = (bs*k, hout)
+    
     ## pass scaling since the result is already pre-scaled on lora_A ! 
     ## apply moe weighted sum for topk loras
     if k > 1: 
@@ -112,7 +115,7 @@ def _moelinear_fwd_inner_bmm_triton_v4(
     ## add the blora result to the base result
     result.add_(blora_results)
     
-    return result
+    return result, result_moe
 
 
 ###########################        version 3        ###########################
@@ -166,6 +169,9 @@ def _moelinear_fwd_inner_bmm_triton_v3(
         blora_B
     ).squeeze(1) * bscalings
     
+    # save and return blora_results for backward
+    result_moe = blora_results # shape = (bs*k, hout)
+    
     ## apply moe weighted sum for topk loras
     if k > 1:
         blora_results *= moe_weights
@@ -174,7 +180,7 @@ def _moelinear_fwd_inner_bmm_triton_v3(
     ## add the blora result to the base result
     result.add_(blora_results.to(x.dtype))
     
-    return result
+    return result, result_moe
 
 
 ###########################        version 2        ###########################
@@ -232,7 +238,7 @@ def _moelinear_fwd_inner_bmm_triton_v2(
         block_size_h=128,
         block_size_hout=128,
         block_size_m=16, # NOTE: to avoid tl.dot error for all dimensions should be >= 16, we use the minimum size 16 here (actucally it is always 1)
-        block_size_r=16,
+        block_size_r=max(16, r),
         num_warps=4,
         num_stages=2,
     )
@@ -254,6 +260,8 @@ def _moelinear_fwd_inner_bmm_triton_v2(
     ##############################      postprocess output     ##############################
     ## scaling
     blora_results = blora_results.squeeze(1) * bscalings  # shape from (bs*k, 1, hout) to (bs*k, hout)
+    # save and return blora_results for backward
+    result_moe = blora_results # shape = (bs*k, hout)
     ## apply moe weighted sum for topk loras
     if k > 1: 
         blora_results *= moe_weights # shape = (bs*k, hout)
@@ -262,7 +270,7 @@ def _moelinear_fwd_inner_bmm_triton_v2(
     ## add the blora result to the base result
     result.add_(blora_results.to(x.dtype))
     
-    return result
+    return result, result_moe
 
 
 ###########################        version 1        ###########################
@@ -308,6 +316,8 @@ def _moelinear_fwd_inner_bmm_triton_v1(
         blora_B # shape: (bs*k, 1, r) =>(bs*k, 1, hout)
     ).squeeze(1) * bscalings # shape: (bs*k, 1, hout) => (bs*k, hout)
     
+    # save and return blora_results for backward
+    result_moe = blora_results # shape = (bs*k, hout)
     ## apply moe weighted sum for topk loras
     if k > 1:
         blora_results *= moe_weights
@@ -316,7 +326,7 @@ def _moelinear_fwd_inner_bmm_triton_v1(
     ## add the blora result to the base result
     result.add_(blora_results.to(x.dtype))
     
-    return result
+    return result, result_moe
 
 
 ###########################        version 0        ###########################

--- a/MoELoRA/layer_ops/layer_ops_triton_backward.py
+++ b/MoELoRA/layer_ops/layer_ops_triton_backward.py
@@ -1,0 +1,392 @@
+from typing import Tuple
+
+import torch
+import torch.nn.functional as F
+
+import triton
+
+from .layer_ops_triton_kernel_backward import triton_bmm, blora_bp_kernel, blora_bp_kernel_with_loraB_mask, blora_bp_kernel_without_mask, moe_weigths_bp_kernel
+
+
+def _get_strides(x, dims=None, ndims=-1):
+    
+    strides = [x.stride(i) for i in range(len(x.shape))]
+    
+    if dims is not None: return [s for i, s in enumerate(strides) if i in dims]
+    if ndims is not None: return strides[:ndims]
+    return strides
+
+###########################        version 4        ###########################
+
+# copied from torch v2, but reshape (x, blA, blB) to avoid too many unnecessary computations
+
+def _moelinear_bp_inner_bmm_triton_without_mask_v4(
+        dr: torch.Tensor, dx: torch.Tensor, 
+        lora_A_weights: torch.Tensor, lora_B_weights: torch.Tensor, 
+        scalings: torch.Tensor, lora_dropout: torch.nn.Module,
+        moe_weights: torch.Tensor, selected_loras: torch.Tensor, 
+        lora_B_mask: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+    
+    # get shapes
+    bs, k = dr.shape[0], moe_weights.shape[-1]
+    h, hout = dx.shape[-1], dr.shape[-1]
+    hm, rm = lora_A_weights.shape[1:]
+    r = lora_B_weights.shape[1]
+    bsk, m = bs * k, h // hm
+    
+    # check shapes
+    assert 16 <= rm <= 128 and 16 <= m <= 64 and 1 <= r <= 64, \
+        f"""
+        `rank (r) * group_size (m)` should be in the range [16, 128],
+        `group_size (m)` should be in the range [16, 64],
+        `rank (r)` should be in the range [1, 64],
+        but we got: group_size: {m} | rank: {r} |
+        """
+    
+    ##############################      preprocess input / output     ##############################
+    
+    ## prepare inputs
+    # x = x[:, None, :] # shape from (bs, h) to (bs, 1, h)
+    # x = x.view(bs, hm, m) # shape from (bs, 1, h) => (bs, m, h//m)
+    if k > 1: 
+        moe_weights = moe_weights.view(-1)[:, None] # shape from (bs, k) => (bs*k, 1)
+        selected_loras = selected_loras.view(-1) # shape from (bs, k) => (bs*k,)
+    # lA_mask1, lA_mask2 = lora_B_mask[0], lora_B_mask[1]; assert lA_mask1.shape == (m, rm) and lA_mask2.shape == (rm, r)
+
+    ## prepare output buffer with shape: (bsk, hout)
+    blora_results = torch.zeros((bsk, hm, m), dtype=dr.dtype, device=dr.device)
+    
+    ##############################      define meta dict / grid     ##############################
+    ## define the meta dict including block sizes, num of wamps, num of stages, etc
+    meta = dict(
+        k=k, m=m, r=r, rm=rm, hm=hm, hout=hout,
+        block_size_hout=128,
+        block_size_hm=128,
+        block_size_r=max(r, 16),
+        num_warps=8,
+        num_stages=4,
+    )
+    
+    grid = lambda meta: (
+        bsk,
+        triton.cdiv(hm, meta["block_size_hm"]),
+    )
+    
+    ##############################      launch the kernel     ##############################
+    blora_bp_kernel_without_mask[grid](
+        dr, *_get_strides(dr), # shape = (bs, hout), block on bs (bsk // k)
+        blora_results, *_get_strides(blora_results), # shape = (bs*k, hm, m)
+        lora_A_weights, *_get_strides(lora_A_weights), # shape = (l, h//m, r*m), no block, index on l
+        lora_B_weights, *_get_strides(lora_B_weights), # shape = (l, r, hout), block on hout, index on l
+        selected_loras, # shape = (bsk, ), block on bsk
+        **meta,
+    )
+    
+    ##############################      postprocess output     ##############################
+    ## pass scaling since the result is already pre-scaled on lora_A ! 
+    ## apply moe weighted sum for topk loras
+    blora_results = blora_results.permute(0, 2, 1)
+    blora_results = blora_results.view(bsk, -1)
+    if k > 1: 
+        blora_results *= moe_weights # shape = (bs*k, h)
+        blora_results = blora_results.view(bs, k, -1).sum(dim=1) # shape from (bs*k, h) to (bs, h)
+    
+    ## add the blora result to the base result
+    dx.add_(blora_results)
+    
+    return dx
+
+def _moelinear_bp_inner_bmm_triton_v4(
+        dr: torch.Tensor, dx: torch.Tensor, 
+        lora_A_weights: torch.Tensor, lora_B_weights: torch.Tensor, 
+        scalings: torch.Tensor, lora_dropout: torch.nn.Module,
+        moe_weights: torch.Tensor, selected_loras: torch.Tensor, 
+        lora_B_mask: Tuple[torch.Tensor, torch.Tensor],
+    ) -> torch.Tensor:
+    
+    # get shapes
+    bs, k = dr.shape[0], moe_weights.shape[-1]
+    h, hout = dx.shape[-1], dr.shape[-1]
+    rn, hn = lora_B_weights.shape[1:]
+    r = lora_A_weights.shape[2]
+    bsk, n = bs * k, hout // hn
+    
+    # check shapes
+    assert 16 <= rn <= 128 and 16 <= n <= 64 and 1 <= r <= 64, \
+        f"""
+        `rank (r) * group_size (m)` should be in the range [16, 128],
+        `group_size (m)` should be in the range [16, 64],
+        `rank (r)` should be in the range [1, 64],
+        but we got: group_size: {n} | rank: {r} |
+        """
+    
+    # prepare inputs
+    dr = dr[:, None, :] # shape from (bs, hout) to (bs, 1, hout)
+    dr = dr.view(bs, hn, n)
+    if k > 1: 
+        moe_weights = moe_weights.view(-1)[:, None] # shape from (bs, k) => (bs*k, 1)
+        selected_loras = selected_loras.view(-1) # shape from (bs, k) => (bs*k,)
+    lB_mask1, lB_mask2 = lora_B_mask[0], lora_B_mask[1]; assert lB_mask1.shape == (rn, n) and lB_mask2.shape == (r, rn)
+    
+    # prepare output buffer with shape (bsk, h)
+    blora_results = torch.zeros((bsk, h), dtype=dr.dtype, device=dr.device)
+    
+    ##############################      define meta dict / grid     ##############################
+    ## define the meta dict including block sizes, num of wamps, num of stages, etc
+    meta = dict(
+        k=k, n=n, r=r, rn=rn, hn=hn, h=h,
+        block_size_h=128,
+        block_size_hn=128,
+        block_size_r=max(r, 16),
+        num_warps=8,
+        num_stages=4,
+    )
+    
+    grid = lambda meta: (
+        bsk,
+        triton.cdiv(h, meta["block_size_h"]),
+    )
+    
+    ##############################      launch the kernel     ##############################
+    blora_bp_kernel_with_loraB_mask[grid](
+        dr, *_get_strides(dr),
+        blora_results, *_get_strides(blora_results), # shape = (bs*k, hout), block on bsk + hout
+        lora_A_weights, *_get_strides(lora_A_weights), # shape = (l, h//m, r*m), no block, index on l
+        lora_B_weights, *_get_strides(lora_B_weights), # shape = (l, r, hout), block on hout, index on l
+        lB_mask1, *_get_strides(lB_mask1), # shape = (m, rm), no block
+        lB_mask2, *_get_strides(lB_mask2), # shape = (rm, r), no block 
+        selected_loras, # shape = (bsk, ), block on bsk
+        **meta,
+    )
+    
+    ##############################      postprocess output     ##############################
+    ## pass scaling since the result is already pre-scaled on lora_A ! 
+    ## apply moe weighted sum for topk loras
+    if k > 1: 
+        blora_results *= moe_weights # shape = (bs*k, hout)
+        blora_results = blora_results.view(bs, k, -1).sum(dim=1) # shape from (bs*k, h) to (bs, h)
+    
+    # add the blora result to the base result
+    dx.add_(blora_results)
+    
+    return dx
+
+
+###########################        version 3        ###########################
+
+# copied from version 1, but reshape (x, blA, blB) to avoid too many unnecessary computations
+def _moelinear_bp_inner_bmm_triton_v3(
+        dr: torch.Tensor, dx: torch.Tensor, 
+        lora_A_weights: torch.Tensor, lora_B_weights: torch.Tensor, 
+        scalings: torch.Tensor, lora_dropout: torch.nn.Module,
+        moe_weights: torch.Tensor, selected_loras: torch.Tensor, 
+        lora_B_mask: torch.Tensor,
+    ) -> torch.Tensor:
+    bs, k = dr.shape[0], moe_weights.shape[-1]
+    h, hout = dx.shape[-1], dr.shape[-1]
+    n = hout // lora_B_weights.shape[-1]
+    r = lora_B_weights.shape[1] // n
+    bsk = bs * k
+    
+    assert lora_B_mask.shape == (n, r*n)
+    
+    # prepare batched input and moe weights
+    dr = dr[:, None, :] # shape from (bs, hout) to (bs, 1, hout)
+    if k > 1:
+        dr = dr.expand(bs, k, -1).reshape(bs*k, 1, -1)  # shape from (bs, 1, h) to (bs*k, 1, h)
+        moe_weights = moe_weights.view(-1)[:, None] # shape from (bs, k) to (bs*k, 1)
+    dr = dr.view(bs*k, n, hout//n)
+    
+    # prepare batched selected (loraA, loraB, scalings)
+    selected_loras = selected_loras.view(-1) # shape from (bs, k) to (bs*k,)
+    blora_A = lora_A_weights[selected_loras].contiguous() # shape from (l, h, r) to (bs*k, h, r)
+    blora_B = lora_B_weights[selected_loras].contiguous() # shape from (l, r*n, hout//n) to (bs*k, r*n, hout//n)
+    blora_A = blora_A.permute(0, 2, 1).contiguous()
+    blora_B = blora_B.permute(0, 2, 1).contiguous()
+    bscalings = scalings[selected_loras][:, None].contiguous() # from (l,) to (bs*k, 1)
+    
+    # apply bmm for each (token_idx, top_idx) to its selected (loraA, loraB, scalings)
+    blora_results = triton_bmm(
+        triton_bmm(dr, blora_B)[lora_B_mask[None, :].expand(bsk, -1, -1)].view(bsk, n, -1).sum(dim=1, keepdim=True), # shape: (bs*k, n, h//n) => (bs*k, r*n) => (bs*k, n, r) => (bs*k, 1, r)
+        blora_A # shape: (bs*k, 1, r) => (bs*k, 1, h)
+    ).squeeze(1) * bscalings # shape: (bs*k, 1, h) => (bs*k, h)
+    
+    # apply moe weighted sum for topk loras
+    if k > 1:
+        blora_results *= moe_weights
+        blora_results = blora_results.view(bs, k, -1).sum(dim=1) # shape from (bs*k, h) to (bs, h)
+    
+    # add the blora result to the base result
+    dx.add_(blora_results.to(dr.dtype))
+    
+    return dx
+
+###########################        version 2        ###########################
+
+# copied from torch v1, and fuse torch.bmm(torch.bmm(x, blA), blB) into blora_fwd_kernel
+# NOTE: here we also parallel batch dim into the maximum bsk blocks, 
+# in which we only parallel dim hout by blocks
+# and we also use selected loras to duplicately index (bs*k) loras without sharing
+def _moelinear_bp_inner_bmm_triton_v2(
+        dr: torch.Tensor, dx: torch.Tensor, 
+        lora_A_weights: torch.Tensor, lora_B_weights: torch.Tensor, 
+        scalings: torch.Tensor, lora_dropout: torch.nn.Module,
+        moe_weights: torch.Tensor, selected_loras: torch.Tensor, 
+    ) -> torch.Tensor:
+    bs, k = dr.shape[0], moe_weights.shape[-1]
+    r = lora_A_weights.shape[-1]
+    h, hout = dx.shape[-1], dr.shape[-1]
+    bsk = bs * k
+    
+    ##############################      preprocess input / output     ##############################
+    dr = dr[:, None, :] # shape from (bs, hout) to (bs, 1, hout)
+    ## prepare batched input and moe weights
+    if k > 1:
+        dr = dr.expand(bs, k, -1).reshape(bsk, 1, -1)  # shape from (bs, 1, hout) to (bs*k, 1, hout)
+        moe_weights = moe_weights.view(-1)[:, None] # shape from (bs, k) to (bs*k, 1)
+    # x = lora_dropout(x) # shape: (bs*k, 1, h)
+    
+    ## prepare batched selected (loraA, loraB, scalings)
+    selected_loras = selected_loras.view(-1) # shape from (bs, k) to (bs*k,)
+    blora_A = lora_A_weights[selected_loras].contiguous() # shape from (l, h, r) to (bs*k, h, r)
+    blora_B = lora_B_weights[selected_loras].contiguous() # shape from (l, r, hout) to (bs*k, r, hout)
+    bscalings = scalings[selected_loras][:, None].contiguous() # from (l,) to (bs*k, 1)
+    
+    ## prepare output buffer (FIXME: should it be torch.float32 ?)
+    blora_results = torch.zeros((bsk, 1, h), dtype=torch.float16, device=dr.device) # shape: (bs*k, 1, h)
+    
+    ##############################      define meta dict / grid     ##############################
+    ## define the meta dict including block sizes, num of wamps, num of stages, etc
+    meta = dict(
+        h=h, hout=hout, m=1, r=r, 
+        block_size_h=128,
+        block_size_hout=128,
+        block_size_m=16, # NOTE: to avoid tl.dot error for all dimensions should be >= 16, we use the minimum size 16 here (actucally it is always 1)
+        block_size_r=max(16 ,r),
+        num_warps=4,
+        num_stages=2,
+    )
+    
+    grid = lambda meta: (
+        bsk,
+        triton.cdiv(h, meta["block_size_h"]),
+    )
+    
+    ##############################      launch the kernel     ##############################
+    blora_bp_kernel[grid](
+        dr, dr.stride(0), dr.stride(1), dr.stride(2),
+        blora_results, blora_results.stride(0), blora_results.stride(1), blora_results.stride(2),
+        blora_A, blora_A.stride(0), blora_A.stride(1), blora_A.stride(2),
+        blora_B, blora_B.stride(0), blora_B.stride(1), blora_B.stride(2),
+        **meta,
+    )
+    
+    ##############################      postprocess output     ##############################
+    ## scaling
+    blora_results = blora_results.squeeze(1) * bscalings  # shape from (bs*k, 1, h) to (bs*k, h)
+    ## apply moe weighted sum for topk loras
+    if k > 1: 
+        blora_results *= moe_weights # shape = (bs*k, h)
+        blora_results = blora_results.view(bs, k, -1).sum(dim=1) # shape from (bs*k, hout) to (bs, h)
+    
+    ## add the blora result to the base result
+    dx.add_(blora_results.to(dr.dtype))
+    
+    
+    
+    return dx
+
+###########################        version 1        ###########################
+
+# copied from torch v1, and just replace torch.bmm for triton_bmm
+def _moelinear_bp_inner_bmm_triton_v1(
+        dr: torch.Tensor, dx: torch.Tensor, 
+        lora_A_weights: torch.Tensor, lora_B_weights: torch.Tensor, 
+        scalings: torch.Tensor, lora_dropout: torch.nn.Module,
+        moe_weights: torch.Tensor, selected_loras: torch.Tensor, 
+    ) -> torch.Tensor:
+    
+    bs, k = dr.shape[0], moe_weights.shape[-1]
+    
+    # prepare batched input and moe weights
+    dr = dr[:, None, :] # shape from (bs, hout) to (bs, 1, hout)
+    if k > 1:
+        dr = dr.expand(bs, k, -1).reshape(bs*k, 1, -1)  # shape from (bs, 1, h) to (bs*k, 1, h)
+        moe_weights = moe_weights.view(-1)[:, None] # shape from (bs, k) to (bs*k, 1)
+    
+    # prepare batched selected (loraA, loraB, scalings)
+    selected_loras = selected_loras.view(-1) # shape from (bs, k) to (bs*k,)
+    blora_A = lora_A_weights[selected_loras].contiguous() # shape from (l, h, r) to (bs*k, h, r)
+    blora_B = lora_B_weights[selected_loras].contiguous() # shape from (l, r, hout) to (bs*k, r, hout)
+    blora_A = blora_A.permute(0, 2, 1).contiguous()
+    blora_B = blora_B.permute(0, 2, 1).contiguous()
+    bscalings = scalings[selected_loras][:, None].contiguous() # from (l,) to (bs*k, 1)
+    
+    # apply bmm for each (token_idx, top_idx) to its selected (loraA, loraB, scalings)
+    blora_results = triton_bmm(
+        triton_bmm(dr, blora_B), # shape: (bs*k, 1, h) => (bs*k, 1, r)
+        blora_A # shape: (bs*k, 1, r) => (bs*k, 1, h)
+    ).squeeze(1) * bscalings # shape: (bs*k, 1, h) => (bs*k, h)
+    
+    # apply moe weighted sum for topk loras
+    if k > 1:
+        blora_results *= moe_weights
+        blora_results = blora_results.view(bs, k, -1).sum(dim=1) # shape from (bs*k, h) to (bs, h)
+    
+    # add the blora result to the base result
+    dx.add_(blora_results.to(dr.dtype))
+    
+    return dx
+
+
+def _moelinear_bp_inner_bmm_triton_weights(
+        dr: torch.Tensor, dk: torch.Tensor,
+        dw: torch.Tensor, moe_weights: torch.Tensor
+    ) -> torch.Tensor:
+    bs, k = dr.shape[0], moe_weights.shape[-1]
+    hout = dr.shape[-1]
+    bsk = bs * k
+    
+    ##############################      preprocess input / output     ##############################
+    if k > 1:
+        dr = dr[:, None, :]
+        dr = dr.expand(bs, k, -1)
+        dr = dr.contiguous().view(bsk, -1) # shape = (bsk, hout)
+        dk = dk.view(bsk, -1) # shape = (bsk, hout)
+    
+    # prepare output buffer
+    weights_results = torch.zeros((bsk, hout), dtype=torch.float32, device=dr.device) # shape = (bsk, hout)
+    
+    ##############################      define meta dict / grid     ##############################
+    ## define the meta dict including block sizes, num of wamps, num of stages, etc
+    meta = dict(
+        hout=hout,
+        block_size_hout=128,
+        num_warps=4,
+        num_stages=2,
+    )
+    
+    grid = lambda meta: (
+        bsk,
+        triton.cdiv(hout, meta["block_size_hout"])
+    )
+    
+    ##############################      launch the kernel     ##############################
+    moe_weigths_bp_kernel[grid](
+        dr, dr.stride(0), dr.stride(1),
+        dk, dk.stride(0), dk.stride(1),
+        weights_results, weights_results.stride(0), weights_results.stride(1),
+        **meta
+    )
+    
+    ##############################      postprocess output     ##############################
+    weights_results = weights_results.sum(dim=1).view(bs, k)
+    weights_results /= moe_weights
+    
+    # add the weights result to the base result
+    dw.add_(weights_results)
+    
+    return dw
+    
+    

--- a/MoELoRA/layer_ops/layer_ops_triton_function.py
+++ b/MoELoRA/layer_ops/layer_ops_triton_function.py
@@ -1,0 +1,201 @@
+import torch
+from typing import Tuple
+from .layer_ops_triton_backward import _moelinear_bp_inner_bmm_triton_weights
+
+################################### v4 ####################################
+from .layer_ops_triton import _moelinear_fwd_inner_bmm_triton_v4
+from .layer_ops_triton_backward import _moelinear_bp_inner_bmm_triton_v4
+
+class MoeLinear_Inner_Bmm_Triton_v4(torch.autograd.Function):
+    
+    @staticmethod
+    def forward(ctx, x: torch.Tensor, result: torch.Tensor,
+                lora_A_weights: torch.Tensor, lora_A_weights_split: torch.Tensor,
+                lora_B_weights: torch.Tensor, lora_B_weights_split: torch.Tensor,
+                scalings: torch.Tensor, lora_dropout: torch.nn.Module,
+                moe_weights: torch.Tensor, selected_loras: torch.Tensor,
+                lora_A_mask: Tuple[torch.Tensor, torch.Tensor],
+                lora_B_mask: Tuple[torch.Tensor, torch.Tensor]
+            ) -> torch.Tensor:
+        
+        kwargs = dict(
+            x=x, result=result,
+            lora_A_weights=lora_A_weights_split, lora_B_weights=lora_B_weights,
+            scalings=scalings, lora_dropout=lora_dropout,
+            moe_weights=moe_weights, selected_loras=selected_loras,
+            lora_A_mask=lora_A_mask
+        )
+        _, result_moe = _moelinear_fwd_inner_bmm_triton_v4(**kwargs)
+        
+        x_shape_tensor = torch.IntTensor([x.shape[0], x.shape[1]])
+        
+        ctx.save_for_backward(x_shape_tensor, lora_A_weights, lora_B_weights_split,
+                              scalings, lora_dropout, moe_weights, selected_loras,
+                              lora_B_mask[0], lora_B_mask[1], result_moe)
+        return result
+    
+    @staticmethod
+    def backward(ctx, grad_outputs):
+        x_shape_tensor, lora_A_weights, lora_B_weights,\
+                scalings, lora_dropout, moe_weights, selected_loras,\
+                              lora_B_mask1, lora_B_mask2, result_moe, = ctx.saved_tensors
+        # dx = torch.zeros(x_shape, dtype=grad_outputs.type, device=grad_outputs.device)
+        # dx = torch.zeros_like(x)
+        dx = torch.zeros((x_shape_tensor[0].item(), x_shape_tensor[1].item()), dtype=grad_outputs.dtype, device=grad_outputs.device)
+        dmoe = torch.zeros_like(moe_weights)
+        
+        kwargs = dict(
+            dr=grad_outputs, dx=dx,
+            lora_A_weights=lora_A_weights, lora_B_weights=lora_B_weights,
+            scalings=scalings, lora_dropout=lora_dropout,
+            moe_weights=moe_weights, selected_loras=selected_loras,
+            lora_B_mask=(lora_B_mask1, lora_B_mask2)
+        )
+        
+        _moelinear_bp_inner_bmm_triton_v4(**kwargs)
+        _moelinear_bp_inner_bmm_triton_weights(grad_outputs, result_moe, dmoe, moe_weights)
+        
+        return dx, None, None, None, None, None, None, None, dmoe, None, None, None 
+        
+
+################################### v3 ####################################
+from .layer_ops_triton import _moelinear_fwd_inner_bmm_triton_v3
+from .layer_ops_triton_backward import _moelinear_bp_inner_bmm_triton_v3
+
+class MoeLinear_Inner_Bmm_Triton_v3(torch.autograd.Function):
+    
+    @staticmethod
+    def forward(ctx, x: torch.Tensor, result: torch.Tensor,
+                lora_A_weights: torch.Tensor, lora_A_weights_split: torch.Tensor,
+                lora_B_weights: torch.Tensor, lora_B_weights_split: torch.Tensor,
+                scalings: torch.Tensor, lora_dropout: torch.nn.Module,
+                moe_weights: torch.Tensor, selected_loras: torch.Tensor,
+                lora_A_mask: torch.Tensor,
+                lora_B_mask: torch.Tensor
+            ) -> torch.Tensor:
+        
+        kwargs = dict(
+            x=x, result=result,
+            lora_A_weights=lora_A_weights_split, lora_B_weights=lora_B_weights,
+            scalings=scalings, lora_dropout=lora_dropout,
+            moe_weights=moe_weights, selected_loras=selected_loras,
+            lora_A_mask=lora_A_mask
+        )
+        _, result_moe = _moelinear_fwd_inner_bmm_triton_v3(**kwargs)
+        
+        x_shape_tensor = torch.IntTensor([x.shape[0], x.shape[1]])
+        
+        ctx.save_for_backward(x_shape_tensor, lora_A_weights, lora_B_weights_split,
+                              scalings, lora_dropout, moe_weights, selected_loras,
+                              lora_B_mask, result_moe)
+        return result
+    
+    @staticmethod
+    def backward(ctx, grad_outputs):
+        x_shape_tensor, lora_A_weights, lora_B_weights,\
+                scalings, lora_dropout, moe_weights, selected_loras,\
+                              lora_B_mask, result_moe, = ctx.saved_tensors
+        # dx = torch.zeros(x_shape, dtype=grad_outputs.type, device=grad_outputs.device)
+        # dx = torch.zeros_like(x)
+        dx = torch.zeros((x_shape_tensor[0].item(), x_shape_tensor[1].item()), dtype=grad_outputs.dtype, device=grad_outputs.device)
+        dmoe = torch.zeros_like(moe_weights)
+        
+        kwargs = dict(
+            dr=grad_outputs, dx=dx,
+            lora_A_weights=lora_A_weights, lora_B_weights=lora_B_weights,
+            scalings=scalings, lora_dropout=lora_dropout,
+            moe_weights=moe_weights, selected_loras=selected_loras,
+            lora_B_mask=lora_B_mask
+        )
+        
+        _moelinear_bp_inner_bmm_triton_v3(**kwargs)
+        _moelinear_bp_inner_bmm_triton_weights(grad_outputs, result_moe, dmoe, moe_weights)
+        
+        return dx, None, None, None, None, None, None, None, dmoe, None, None, None 
+
+################################### v2 ####################################
+from .layer_ops_triton import _moelinear_fwd_inner_bmm_triton_v2
+from .layer_ops_triton_backward import _moelinear_bp_inner_bmm_triton_v2
+
+class MoeLinear_Inner_Bmm_Triton_v2(torch.autograd.Function):
+    
+    @staticmethod
+    def forward(ctx, x: torch.Tensor, result: torch.Tensor, 
+        lora_A_weights: torch.Tensor, lora_B_weights: torch.Tensor, 
+        scalings: torch.Tensor, lora_dropout: torch.nn.Module,
+        moe_weights: torch.Tensor, selected_loras: torch.Tensor):
+        
+        kwargs = dict(
+            x=x, result=result,
+            lora_A_weights=lora_A_weights, lora_B_weights=lora_B_weights,
+            scalings=scalings, lora_dropout=lora_dropout,
+            moe_weights=moe_weights, selected_loras=selected_loras,
+        )
+        _, result_moe = _moelinear_fwd_inner_bmm_triton_v2(**kwargs)
+        x_shape_tensor = torch.IntTensor([x.shape[0], x.shape[1]])
+        ctx.save_for_backward(x_shape_tensor, lora_A_weights, lora_B_weights, scalings, 
+                              moe_weights, selected_loras, result_moe)
+        return result
+    
+    @staticmethod
+    def backward(ctx, grad_outputs):
+        x_shape_tensor, lora_A_weights, lora_B_weights, scalings, \
+            moe_weights, selected_loras, blora_result = ctx.saved_tensors
+        # dx = torch.zeros_like(x)
+        dx = torch.zeros((x_shape_tensor[0].item(), x_shape_tensor[1].item()), dtype=grad_outputs.dtype, device=grad_outputs.device)
+        dmoe = torch.zeros_like(moe_weights)
+        
+        kwargs = dict(
+            dr=grad_outputs, dx=dx,
+            lora_A_weights=lora_A_weights, lora_B_weights=lora_B_weights,
+            scalings=scalings, lora_dropout=None,
+            moe_weights=moe_weights, selected_loras=selected_loras,
+        )
+        
+        _moelinear_bp_inner_bmm_triton_v2(**kwargs)
+        _moelinear_bp_inner_bmm_triton_weights(grad_outputs, blora_result, dmoe, moe_weights)
+        return dx, None, None, None, None, None, dmoe, None
+
+
+from .layer_ops_triton import _moelinear_fwd_inner_bmm_triton_v1
+from .layer_ops_triton_backward import _moelinear_bp_inner_bmm_triton_v1
+
+################################### v1 ####################################
+class MoeLinear_Inner_Bmm_Triton_v1(torch.autograd.Function):
+    
+    @staticmethod
+    def forward(ctx, x: torch.Tensor, result: torch.Tensor, 
+        lora_A_weights: torch.Tensor, lora_B_weights: torch.Tensor, 
+        scalings: torch.Tensor, lora_dropout: torch.nn.Module,
+        moe_weights: torch.Tensor, selected_loras: torch.Tensor):
+        
+        kwargs = dict(
+            x=x, result=result,
+            lora_A_weights=lora_A_weights, lora_B_weights=lora_B_weights,
+            scalings=scalings, lora_dropout=lora_dropout,
+            moe_weights=moe_weights, selected_loras=selected_loras,
+        )
+        _, result_moe = _moelinear_fwd_inner_bmm_triton_v1(**kwargs)
+        x_shape_tensor = torch.IntTensor([x.shape[0], x.shape[1]])
+        ctx.save_for_backward(x_shape_tensor, lora_A_weights, lora_B_weights, scalings, 
+                              moe_weights, selected_loras, result_moe)
+        return result
+    
+    @staticmethod
+    def backward(ctx, grad_outputs):
+        x_shape_tensor, lora_A_weights, lora_B_weights, scalings, \
+            moe_weights, selected_loras, blora_result = ctx.saved_tensors
+        # dx = torch.zeros_like(x)
+        dx = torch.zeros((x_shape_tensor[0].item(), x_shape_tensor[1].item()), dtype=grad_outputs.dtype, device=grad_outputs.device)
+        dmoe = torch.zeros_like(moe_weights)
+        
+        kwargs = dict(
+            dr=grad_outputs, dx=dx,
+            lora_A_weights=lora_A_weights, lora_B_weights=lora_B_weights,
+            scalings=scalings, lora_dropout=None,
+            moe_weights=moe_weights, selected_loras=selected_loras,
+        )
+        
+        _moelinear_bp_inner_bmm_triton_v1(**kwargs)
+        _moelinear_bp_inner_bmm_triton_weights(grad_outputs, blora_result, dmoe, moe_weights)
+        return dx, None, None, None, None, None, dmoe, None

--- a/MoELoRA/layer_ops/layer_ops_triton_kernel_backward.py
+++ b/MoELoRA/layer_ops/layer_ops_triton_kernel_backward.py
@@ -1,0 +1,409 @@
+import torch
+import torch.nn.functional as F
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def bmm_kernel( # naive grid sequence organized in row-major order inter-group, and column-major order intra-group, with fp16 precision
+    x_ptr, x_stride_b, x_stride_m, x_stride_k,
+    y_ptr, y_stride_b, y_stride_k, y_stride_n,
+    o_ptr, o_stride_b, o_stride_m, o_stride_n,
+    m: tl.constexpr, n: tl.constexpr, k: tl.constexpr,
+    # meta parameters
+    block_size_m: tl.constexpr, block_size_n: tl.constexpr, block_size_k: tl.constexpr,
+    group_size_m: tl.constexpr,
+):
+    ### init the pointers
+    
+    ## get the batch idx and (row,col) block idxs by groups in an inter-group row-major order and an intra-group col-major order 
+    batch_idx = tl.program_id(axis=0) # the first axis for the batch idx in the batch
+    block_idx = tl.program_id(axis=1) # the second axis for the block idx in the 2d matrix
+    num_blocks_m = tl.cdiv(m, block_size_m) # the number of blocks in row dim
+    num_blocks_n = tl.cdiv(n, block_size_n) # the number of blocks in col dim
+    num_blocks_g = group_size_m * num_blocks_n # the number of 2d blocks in a group
+    group_idx = block_idx // num_blocks_g # 1d group idx
+    first_block_m = group_idx * group_size_m # the row block idx of the first block in that group
+    group_size_m_ = min(num_blocks_m - first_block_m , group_size_m) # get the group size of that group, normally it equals `group_size_m`, but the last group may be less
+    block_idx_m = first_block_m + (block_idx % group_size_m_) # get the row block idx of current block in that group in a col-major order
+    block_idx_n = (block_idx % num_blocks_g) // group_size_m_ # get the col block idx of current block in that group in a col-major order
+    
+    ## get the 2d block pointers for o: shape=(block_size_m, block_size_n)
+    block_ptrs_m = (block_idx_m * block_size_m + tl.arange(0, block_size_m)) % m # NOTE: mod m to avoid oob row offsets during computaion, but may leave redundant last row block idx: (m-1) and compute repeatitive values
+    block_ptrs_n = (block_idx_n * block_size_n + tl.arange(0, block_size_n)) % n # NOTE: mod n to avoid oob col offsets during computaion, but may leave redundant last col block idx: (n-1) and compute repeatitive values
+    
+    ## get each 2d block pointers for x: shape=(block_size_m, block_size_k), y: shape=(block_size_k, block_size_n)
+    offsets_k = tl.arange(0, block_size_k) # split inner dimk by blocks with size `block_size_k`
+    x_block_ptrs = x_ptr + (block_ptrs_m[:, None] * x_stride_m + offsets_k[None, :] * x_stride_k) + (batch_idx * x_stride_b) # the start block along dimk for x
+    y_block_ptrs = y_ptr + (offsets_k[:, None] * y_stride_k + block_ptrs_n[None, :] * y_stride_n) + (batch_idx * y_stride_b) # the start block along dimk for y
+    
+    
+    ### do the operations
+    # we iterate the kdim to compute a `[block_size_m, block_size_n]` block of the otuput matrix.
+    # to get higher accuracy, we accumulate each block along dimk into a upcasted fp32 values `accumulator`
+    # and the `accumulator` will be downcasted back to fp16 after the loop.
+    o = tl.zeros((block_size_m, block_size_n), dtype=tl.float32) # upcast to fp32
+    for block_idx_k in range(0, tl.cdiv(k, block_size_k)):
+        block_offs_k = block_idx_k * block_size_k + offsets_k
+        # load current block of x and y along dimk with mask to avoid oob, where oob values are set to 0.
+        x = tl.load(x_block_ptrs, mask=block_offs_k[None, :] < k, other=0.)
+        y = tl.load(y_block_ptrs, mask=block_offs_k[:, None] < k, other=0.)
+        
+        # compute x @ y for this block along dimk and add to `accumulator`
+        o += tl.dot(x, y)
+        
+        # move x,y pointers to next block along dimk
+        x_block_ptrs += block_size_k * x_stride_k
+        y_block_ptrs += block_size_k * y_stride_k
+    # o = o.to(tl.float16) # downcast to fl16
+        
+    ### store the output data from SRAM to HBM
+    block_ptrs_m_ = block_idx_m * block_size_m + tl.arange(0, block_size_m)[:, None] # NOTE: here to store right output value, we need to remove the redundant (m-1) idx but use the real idx awith mask to avoid oob
+    block_ptrs_n_ = block_idx_n * block_size_n + tl.arange(0, block_size_n)[None, :] # NOTE: here to store right output value, we need to remove the redundant (m-1) idx but use the real idx with mask to avoid oob
+    o_ptrs = o_ptr + (block_ptrs_m_ * o_stride_m + block_ptrs_n_ * o_stride_n) + (batch_idx * o_stride_b)
+    block_mask_mn = (block_ptrs_m_  < m) & (block_ptrs_n_ < n) # 2d block mask to avoid oob
+    tl.store(o_ptrs, o, mask=block_mask_mn)
+    
+
+def triton_bmm(x: torch.tensor, y: torch.tensor) -> torch.tensor:
+    # check the input
+    assert x.dim() == y.dim() == 3
+    assert x.shape[2] == y.shape[1] and x.dtype == y.dtype and x.device == y.device
+    assert x.is_contiguous() and y.is_contiguous()
+    
+    # init the output buffer
+    b,m,k = x.shape
+    b,k,n = y.shape
+    
+    o = torch.zeros((b,m,n), dtype=x.dtype, device=x.device)
+    
+    # define some meta parameters
+    # NOTE: we auto-tune the meta parameters like block_size and num_warps using triton.autotune decorator above the kernel
+    meta = dict(
+        block_size_m=16,
+        block_size_n=128,
+        block_size_k=16,
+        group_size_m=8,
+        num_warps=4,
+        num_stages=4, 
+    )
+    
+    # define the grid (number of blocks)
+    grid = lambda meta: (
+        b, 
+        triton.cdiv(m, meta["block_size_m"]) * triton.cdiv(n, meta["block_size_n"]),
+    ) # (b, m x n) blocks, each to compute matmul for xi block and yj block for the kth matrix pair in the batch
+    
+    # launch the kernel
+    bmm_kernel[grid](
+        x, x.stride(0), x.stride(1), x.stride(2),
+        y, y.stride(0), y.stride(1), y.stride(2),
+        o, o.stride(0), o.stride(1), o.stride(2),
+        m, n, k,
+        **meta,
+    )
+    
+    return o 
+
+
+
+@triton.jit
+def blora_bp_kernel_without_mask(
+        dr_ptr, dr_stride_bs,
+        dx_ptr, dx_stride_bsk, dx_stride_hm,
+        lA_ptr, lA_stride_l, lA_stride_hm,
+        lB_ptr, lB_stride_l, lB_stride_r,
+        sel_ptr, 
+        k: tl.constexpr, m: tl.constexpr, r: tl.constexpr, rm: tl.constexpr, 
+        hm: tl.constexpr, hout: tl.constexpr,
+        block_size_hout: tl.constexpr, block_size_hm: tl.constexpr, block_size_r: tl.constexpr,
+    ):
+    
+    ##################       get the block pointers        ##################
+    # get the bsk block index and hout block index
+    block_idx_bsk = tl.program_id(0)
+    block_idx_bs = block_idx_bsk // k
+    # block_idx_hout = tl.program_id(1)
+    block_idx_hm = tl.program_id(1)
+    
+    # get block offsets
+    offsets_hout = tl.arange(0, block_size_hout)
+    offsets_hm = block_idx_hm * block_size_hm + tl.arange(0, block_size_hm)
+    offsets_r = tl.arange(0, block_size_r)
+    offsets_m = tl.arange(0, m)
+    offsets_rm = tl.arange(0, rm)
+    
+    # get block masks
+    block_mask_hout = offsets_hout < hout
+    block_mask_hout_row = offsets_hout[None, :] < hout
+    block_mask_hm_col = offsets_hm[:, None] < hm
+    block_mask_rm_row = offsets_rm[None, :] < rm
+    block_mask_r_col = offsets_r[:, None] < r
+    block_mask_m_row = offsets_r[None, :] < m
+    
+    # get the selected lora idx
+    sel_ptr += block_idx_bsk
+    sel_idx = tl.load(sel_ptr)
+    
+    # get the block pointers for input variables: x, lA, lB, lA_mask1, lA_mask2
+    lA_block_ptrs = lA_ptr + sel_idx * lA_stride_l + \
+                (offsets_hm[:, None] * lA_stride_hm + offsets_rm[None, :]) # shape = (block_size_hm, rm)
+
+    dr_block_ptrs = dr_ptr + block_idx_bs * dr_stride_bs + \
+                ([[0]] + offsets_hout[None, :]) # shape = (1, block_size_hout)
+    lA_block_ptrs = lA_ptr + sel_idx * lA_stride_l + \
+                (offsets_hm[:, None] * lA_stride_hm + offsets_rm) # shape = (block_size_hm, rm)
+    lB_block_ptrs = lB_ptr + sel_idx * lB_stride_l + \
+                (offsets_r[:, None] * lB_stride_r + offsets_hout[None, :]) # shape = (block_size_r, block_size_hout)
+    
+    # get the block pointers for output variables, shape = (block_size_hm, m)
+    dx_block_ptrs = dx_ptr + block_idx_bsk * dx_stride_bsk + offsets_hm[:, None] * dx_stride_hm + offsets_m[None, :]
+    
+    
+    ##################      compute olB = lB.transpose @ dr      ##################
+    compute_olB_dtype = tl.float16
+    
+    #init olB buffer, shape = (block_size_r, 1)
+    olB = tl.zeros((block_size_r, 1))
+    # loop over hout dim by blocks to accumulate olB
+    for _ in range(tl.cdiv(hout, block_size_hout)):
+        # update block masks
+        block_mask_hout_col = offsets_hout[:, None] < hout
+        block_mask_hout_row = offsets_hout[None, :] < hout
+        
+        # load dr, lB
+        dr = tl.load(dr_block_ptrs, mask=block_mask_hout_row, other=0.).to(compute_olB_dtype) # shape = (1, block_size_hout)
+        lB = tl.load(lB_block_ptrs, mask=block_mask_hout_row, others=0.).to(compute_olB_dtype) # shape = (block_size_r, block_size_hout)
+        
+        # compute olB = lB @ dr
+        olB += tl.dot(lB, dr.T).to(compute_olB_dtype) # shape = (block_size_r, 1)
+        
+        # update block pointers and offsets
+        offsets_hout += block_size_hout
+        dr_block_ptrs += block_size_hout
+        lB_block_ptrs += block_size_hout
+    
+    ##################            expand olB            ##################
+    olB_r = torch.zeros(r*m, m, dtype=compute_olB_dtype, device = olB.device)
+    for i in range(m): olB_r[i*r:(i+1)*r, i] = olB # shape = (r*m, m)
+    
+    ##################      compute olA = lA @ olB_r     ##################
+    compute_olA_dtype = tl.float16
+    
+    # load lA
+    lA = tl.load(lA_block_ptrs, mask = block_mask_hm_col & block_mask_rm_row, other=0.).to(compute_olA_dtype) # shape = (block_size_hm, rm)
+    # compute olA = lA @ olB_r
+    olA = tl.dot(lA, olB.to(compute_olA_dtype)) # shape = (block_size_hm, m)
+    
+    ##################           store output          ##################
+    # store olA with shape = (block_size_hm, m)
+    tl.store(dx_block_ptrs, olA.to(dx_block_ptrs.dtype.element_ty), mask=block_mask_hm_col & block_mask_m_row)
+
+@triton.jit
+def blora_bp_kernel_with_loraB_mask(
+        dr_ptr, dr_stride_bs, dr_stride_n,
+        dx_ptr, dx_stride_bsk,
+        lA_ptr, lA_stride_l, lA_stride_h,
+        lB_ptr, lB_stride_l, lB_stride_rn,
+        lB_mask1_ptr, lB_mask1_stride_rn,
+        lB_mask2_ptr, lB_mask2_stride_r,
+        sel_ptr, 
+        k: tl.constexpr, n: tl.constexpr,
+        r: tl.constexpr, rn: tl.constexpr, 
+        hn: tl.constexpr, h: tl.constexpr,
+        block_size_r: tl.constexpr,
+        block_size_hn: tl.constexpr, block_size_h: tl.constexpr,
+    ):
+    """ 
+    dr shape = (bs, n, hout//n)
+    lora_B_weights shape = (loras, r, hout) -> (loras, rn, hout//n)
+    lora_A_weights shape = (loras, h, r)
+    """
+    
+    ##################       get the block pointers        ##################
+    # get the bsk block index and hout block index
+    block_idx_bsk = tl.program_id(0)
+    block_idx_bs = block_idx_bsk // k
+    block_idx_h = tl.program_id(1)
+    
+    # get block offsets
+    offsets_h = block_idx_h * block_size_h + tl.arange(0, block_size_h)
+    offsets_hn = tl.arange(0, block_size_hn)
+    offsets_r = tl.arange(0, block_size_r)
+    offsets_n = tl.arange(0, n)
+    offsets_rn = tl.arange(0, rn)
+    
+    # get block mask
+    block_mask_h = offsets_h < h
+    block_mask_h_col = offsets_h[:, None] < h
+    block_mask_r_col = offsets_r[:, None] < r
+    block_mask_r_row = offsets_r[None, :] < r
+    
+    # get the selected lora idx
+    sel_ptr += block_idx_bsk
+    sel_idx = tl.load(sel_ptr)
+    
+    # get the block pointers for input variables: dr, lA, lB, lB_mask1, lB_mask2
+    dr_block_ptrs = dr_ptr + block_idx_bs * dr_stride_bs + \
+                (offsets_n[:, None] * dr_stride_n + offsets_hn[None, :]) # shape = (n, block_size_hn)
+    lB_block_ptrs = lB_ptr + sel_idx * lB_stride_l + \
+                (offsets_rn[:, None] * lB_stride_rn + offsets_hn[None, :]) # shape = (rn, block_size_hn)
+    lA_block_ptrs = lA_ptr + sel_idx * lA_stride_l + \
+                (offsets_h[:, None] * lA_stride_h + offsets_r[None, :]) # shape = (block_size_h, block_size_r)
+    lB_mask1_ptrs = lB_mask1_ptr + (offsets_rn[:, None] * lB_mask1_stride_rn + offsets_n[None, :]) # shape = (rn, n)
+    lB_mask2_ptrs = lB_mask2_ptr + (offsets_r[:, None] * lB_mask2_stride_r + offsets_rn[None, :]) # shape = (block_size_r, rn)
+    
+    # get the block pointers for output variables
+    dx_block_ptrs = dx_ptr + block_idx_bsk * dx_stride_bsk + offsets_h # shape = (block_size_h, )
+    
+    ##################      compute olB = lB @ dr.T      ##################
+    compute_olB_dtype = tl.float16
+    
+    # init olB buffer
+    olB = tl.zeros((rn, n), dtype=compute_olB_dtype) # shape = (rn, n)
+    # loop over hn dim by blocks to accumulate olB
+    for block_idx_hn in range(tl.cdiv(hn, block_size_hn)):
+        # update block masks
+        block_mask_hn_col = offsets_hn[:, None] < hn
+        block_mask_hn_row = offsets_hn[None, :] < hn
+        
+        # load dr, lB
+        dr = tl.load(dr_block_ptrs, mask=block_mask_hn_row, other=0.).to(compute_olB_dtype)
+        lB = tl.load(lB_block_ptrs, mask=block_mask_hn_row, other=0.).to(compute_olB_dtype)
+        
+        # compute olB = lB @ dr.T
+        olB += tl.dot(lB, dr.T).to(compute_olB_dtype) # shape = (rn, n)
+        
+        # update block pointers and offsets
+        offsets_hn += block_size_hn
+        dr_block_ptrs += block_size_hn
+        lB_block_ptrs += block_size_hn
+    
+    ##################            mask olB            ##################
+    
+    # load lB_mask1, lB_mask2
+    lB_mask1 = tl.load(lB_mask1_ptrs).to(compute_olB_dtype) # shape = (rn, n)
+    lB_mask2 = tl.load(lB_mask2_ptrs, mask=block_mask_r_col, other=0.).to(compute_olB_dtype) # shape = (block_size_r, rn)
+    # mask olB = lB_mask2 @ (olB * lB_mask1)
+    olB = tl.dot(lB_mask2, olB * lB_mask1) # shape = (block_size_r, n)
+    
+    ##################      compute olA = lA @ olB     ##################
+    compute_olA_dtype = tl.float16
+
+    # load lA
+    lA = tl.load(lA_block_ptrs, mask=block_mask_h_col & block_mask_r_row, other=0.).to(compute_olA_dtype) # shape = (block_size_h, block_size_r)
+    # compute olA = lA @ olB
+    olA = tl.sum(
+        tl.dot(lA, olB.to(compute_olA_dtype)), # shape = (block_size_h, n)
+        axis=1
+    ) # shape = (block_size_h,)
+    
+    ##################           store output          ##################
+    # store olA with shape = (block_size_h,)
+    # TODO check the consistence between the shape of dx_block_ptrs and olA, check the store mask
+    tl.store(dx_block_ptrs, olA.to(dx_block_ptrs.dtype.element_ty), mask=block_mask_h)
+
+
+@triton.jit
+def blora_bp_kernel(
+        dr_ptr, dr_stride_bsk, dr_stride_m, dr_stride_hout,
+        dx_ptr, dx_stride_bsk, dx_stride_m, dx_stride_h,
+        blA_ptr, blA_stride_bsk, blA_stride_h, blA_stride_r,
+        blB_ptr, blB_stride_bsk, blB_stride_r, blB_stride_hout,
+        h: tl.constexpr, hout: tl.constexpr, m: tl.constexpr, r: tl.constexpr,
+        block_size_h: tl.constexpr, block_size_hout: tl.constexpr,
+        block_size_m: tl.constexpr, block_size_r: tl.constexpr,
+    ):
+    ##################      get the pointers for this bsk block      ##################
+    # get the bsk block index and h block index
+    block_idx_bsk = tl.program_id(0)
+    block_idx_h = tl.program_id(1)
+    
+    # get block offsets
+    offsets_h = block_idx_h * block_size_h + tl.arange(0, block_size_h)
+    offsets_hout = tl.arange(0, block_size_hout)
+    offsets_m = tl.arange(0, block_size_m)
+    offsets_r = tl.arange(0, block_size_r)
+    
+    # get block masks
+    block_mask_m_col = offsets_m[:, None] < m
+    block_mask_r_row = offsets_r[None, :] < r
+    block_mask_r_col = offsets_r[:, None] < r
+    block_mask_h_row = offsets_h[None, :] < h
+    block_mask_h_col = offsets_h[:, None] < h
+    
+    # get the variable pointers
+    dx_ptrs = dx_ptr + block_idx_bsk * dx_stride_bsk + \
+                (offsets_m[:, None] * dx_stride_m + offsets_h[None, :] * dx_stride_h) # shape = (block_size_m, block_size_h)
+    dr_ptrs = dr_ptr + block_idx_bsk * dr_stride_bsk + \
+                (offsets_m[:, None] * dr_stride_m + offsets_hout[None, :] * dr_stride_hout) # shape = (block_size_m, block_size_hout)
+    blA_ptrs = blA_ptr + block_idx_bsk * blA_stride_bsk + \
+                (offsets_h[:, None] * blA_stride_h + offsets_r[None, :] * blA_stride_r) # shape = (block_size_h, block_size_r)
+    blB_ptrs = blB_ptr + block_idx_bsk * blB_stride_bsk + \
+                (offsets_r[:, None] * blB_stride_r + offsets_hout[None, :] * blB_stride_hout) # shape = (block_size_r, block_size_hout)
+    
+    ##################      compute olB = blB @ dr.T      ##################
+    olB = tl.zeros((block_size_r, block_size_m), dtype=tl.float32) # shape = (block_size_r, block_size_m)
+    for block_idx_hout in range(0, tl.cdiv(hout, block_size_hout)):
+        # get the offsets and masks for this block along inner dim hout
+        block_offs_hout = block_idx_hout * block_size_hout + offsets_hout
+        block_mask_hout_row = block_offs_hout[None, :] < hout
+        block_mask_hout_col = block_offs_hout[:, None] < hout
+        
+        # load current block of x and blA along inner dimh from HBM to SRAM
+        # with mask to avoid oob, where oob values are set to 0.
+        dr = tl.load(dr_ptrs, mask=block_mask_m_col & block_mask_hout_row, other=0.) # shape = (block_size_m, block_size_hout)
+        blB = tl.load(blB_ptrs, mask=block_mask_r_col & block_mask_hout_row, other=0.) # shape = (block_size_r, block_size_hout)
+        
+        # compute blB @ dr for this block along inner dim hout and add to `accumulator`
+        olB += tl.dot(blB, dr.T) # shape = (block_size_r, block_size_m)
+        
+        # move dr,blB pointers to next block along inner dim hout
+        dr_ptrs += block_size_hout * dr_stride_hout
+        blB_ptrs += block_size_hout * blB_stride_hout
+    
+    ##################      compute olA = olA @ blB     ##################
+    # load blA for this block along dim hout from HBM to SRAM
+    blA = tl.load(blA_ptrs, mask=block_mask_h_col & block_mask_r_row, other=0.).to(tl.float32) # shape = (block_size_h, block_size_r)
+    olA = tl.dot(blA, olB) # shape = (block_size_h, block_size_m)
+    
+    ##################      store output      ##################
+    # store olA for this block along dim h from SRAM to HBM
+    tl.store(dx_ptrs, olA.T, mask=block_mask_m_col & block_mask_h_row) # shape = (block_size_m, block_size_h)
+    
+
+@triton.jit
+def moe_weigths_bp_kernel(
+    dr_ptr, dr_stride_bsk, dr_stride_hout,
+    dk_ptr, dk_stride_bsk, dk_stride_hout,
+    dw_ptr, dw_stride_bsk, dw_stride_hout,
+    hout: tl.constexpr, block_size_hout: tl.constexpr
+):
+    ##################      get the pointers for this bsk block      ##################
+    # get the bsk block index and h block index
+    block_idx_bsk = tl.program_id(0)
+    block_idx_hout = tl.program_id(1)
+    
+    # get block offsets
+    offsets_hout = block_idx_hout * block_size_hout + tl.arange(0, block_size_hout)
+    
+    # get block masks
+    block_mask_hout = offsets_hout < hout
+    
+    # get the variable pointers
+    dr_ptrs = dr_ptr + block_idx_bsk * dr_stride_bsk + offsets_hout * dr_stride_hout # shape = (block_size_hout, )
+    dk_ptrs = dk_ptr + block_idx_bsk * dk_stride_bsk + offsets_hout * dk_stride_hout # shape = (block_size_hout, )
+    dw_ptrs = dw_ptr + block_idx_bsk * dw_stride_bsk + offsets_hout * dw_stride_hout # shape = (block_size_hout, )
+    
+    ##################      compute dw = dr * dk      ##################
+    # load current block of dr and dk from HBM to SRAM
+    # with mask to avoid oob, where oob are set to 0.
+    dr = tl.load(dr_ptrs, mask=block_mask_hout, other=0.) # shape = (block_size_hout, )
+    dk = tl.load(dk_ptrs, mask=block_mask_hout, other=0.) # shape = (block_size_hout, )
+    
+    # compute dw = dr * dk for this block
+    dw = dr * dk
+    
+    # store dw for this block along dim hout from SRAM to HBM
+    tl.store(dw_ptrs, dw, mask=block_mask_hout)


### PR DESCRIPTION
##### changed file:
MoELoRA/layer.py: add lora_B_mask to handle v4 backpropagation and modify some function parameters
MoELoRA/layer_ops/layer_ops_interface.py: advance lora_dropout in the model and introduce a custom function model to handle forward and backward propagation
MoELoRA/layer_ops/layer_ops_triton.py: cancel dropout in v1-v4 models
MoELoRA/layer_ops/layer_ops_triton_kernel.py: save some parameters required for backpropagation and modify the return value

##### new file:
MoELoRA/layer_ops/layer_ops_triton_backward.py: The main function of v1-v4 backpropagation
MoELoRA/layer_ops/layer_ops_triton_kernel_backward.py: v0-v4 Backpropagation Kernel
MoELoRA/layer_ops/layer_ops_triton_function.py: custom propagation module inherited from torch.autograd.function